### PR TITLE
fix: restore filterable template paths using path() helper for default locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 You can see the changes made via the [commit log](https://github.com/themehybrid/hybrid-theme/commits/master) for the latest release.
 
+## [2.0.3] - 2024-10-13
+
+### Changed
+
+- Fix default template locations by making views path filterable using the path() helper function.
+
 ## [2.0.2] - 2024-08-01
 
 ### Changed

--- a/src/View/Provider.php
+++ b/src/View/Provider.php
@@ -19,6 +19,7 @@ namespace Hybrid\Theme\View;
 
 use Hybrid\Core\ServiceProvider;
 use Hybrid\Theme\Facades\View;
+use function Hybrid\Template\path;
 use function Hybrid\Tools\collect;
 
 /**
@@ -69,10 +70,12 @@ class Provider extends ServiceProvider {
      * Boot.
      */
     public function boot() {
+        // Relative path to the templates directory.
+        $templates_path = path();
 
         // Add view paths.
-        View::addLocation( get_stylesheet_directory() . '/views' );
-        View::addLocation( get_template_directory() . '/views' );
+        View::addLocation( get_stylesheet_directory() . '/' . $templates_path );
+        View::addLocation( get_template_directory() . '/' . $templates_path );
 
         View::composer( '*', function ( $view ) {
             $this->maybeShiftAttachment( $view );


### PR DESCRIPTION
* Fixed broken default template locations by making the views path filterable again
* Updated the code to use the `path()` helper function to ensure templates path can be easily filtered